### PR TITLE
Update to 5.0-8357 coinciding with the June 2018 progress report

### DIFF
--- a/appdata.xml
+++ b/appdata.xml
@@ -23,7 +23,7 @@
     <screenshot>https://raw.githubusercontent.com/flathub/org.DolphinEmu.dolphin-emu/master/screenshots/4.png</screenshot>
   </screenshots>
   <releases>
-    <release date="2018-06-16" version="5.0-8138"/>
+    <release date="2018-07-06" version="5.0-8357"/>
   </releases>
   <update_contact>b@bpiotrowski.pl</update_contact>
 </application>

--- a/org.DolphinEmu.dolphin-emu.json
+++ b/org.DolphinEmu.dolphin-emu.json
@@ -73,7 +73,7 @@
         {
           "type": "git",
           "url": "https://github.com/dolphin-emu/dolphin.git",
-          "commit": "b5e6cd97258bff6162b7e75fe2b2a69555a78587"
+          "commit": "28ca6fec9a77b3c4ea58abce558bd79220a2db7d"
         },
         {
           "type": "file",


### PR DESCRIPTION
I've tested it superficially by playing wind waker.
There aren't any obvious regressions, the new feature to 
disable arbitrary mipmap detection works as intended.