### PR TITLE
Prevent dolphin from attempting to write non-standard conf files

### DIFF
--- a/forcexdg.patch
+++ b/forcexdg.patch
@@ -1,0 +1,41 @@
+diff --git a/Source/Core/UICommon/UICommon.cpp b/Source/Core/UICommon/UICommon.cpp
+index 2055c4d863..fdba657953 100644
+--- a/Source/Core/UICommon/UICommon.cpp
++++ b/Source/Core/UICommon/UICommon.cpp
+@@ -273,28 +273,11 @@ void SetUserDirectory(const std::string& custom_path)
+       user_path = home_path + DOLPHIN_DATA_DIR DIR_SEP;
+     }
+ #else
+-    // We are on a non-Apple and non-Android POSIX system, there are 4 cases:
+-    // 1. GetExeDirectory()/portable.txt exists
+-    //    -> Use GetExeDirectory()/User
+-    // 2. $DOLPHIN_EMU_USERPATH is set
+-    //    -> Use $DOLPHIN_EMU_USERPATH
+-    // 3. ~/.dolphin-emu directory exists
+-    //    -> Use ~/.dolphin-emu
+     // 4. Default
+     //    -> Use XDG basedir, see
+     //    http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
+     user_path = home_path + "." DOLPHIN_DATA_DIR DIR_SEP;
+     std::string exe_path = File::GetExeDirectory();
+-    if (File::Exists(exe_path + DIR_SEP "portable.txt"))
+-    {
+-      user_path = exe_path + DIR_SEP "User" DIR_SEP;
+-    }
+-    else if (env_path)
+-    {
+-      user_path = env_path;
+-    }
+-    else if (!File::Exists(user_path))
+-    {
+       const char* data_home = getenv("XDG_DATA_HOME");
+       std::string data_path =
+           std::string(data_home && data_home[0] == '/' ? data_home :
+@@ -316,7 +299,6 @@ void SetUserDirectory(const std::string& custom_path)
+       File::SetUserPath(D_CONFIG_IDX, config_path);
+       File::SetUserPath(D_CACHE_IDX, cache_path);
+       return;
+-    }
+ #endif
+   }
+ #endif

--- a/forcexdg.patch
+++ b/forcexdg.patch
@@ -1,5 +1,5 @@
 diff --git a/Source/Core/UICommon/UICommon.cpp b/Source/Core/UICommon/UICommon.cpp
-index 2055c4d863..fdba657953 100644
+index 2055c4d863..163a15f8a5 100644
 --- a/Source/Core/UICommon/UICommon.cpp
 +++ b/Source/Core/UICommon/UICommon.cpp
 @@ -273,28 +273,11 @@ void SetUserDirectory(const std::string& custom_path)
@@ -31,7 +31,7 @@ index 2055c4d863..fdba657953 100644
        const char* data_home = getenv("XDG_DATA_HOME");
        std::string data_path =
            std::string(data_home && data_home[0] == '/' ? data_home :
-@@ -316,7 +299,6 @@ void SetUserDirectory(const std::string& custom_path)
+@@ -316,11 +299,9 @@ void SetUserDirectory(const std::string& custom_path)
        File::SetUserPath(D_CONFIG_IDX, config_path);
        File::SetUserPath(D_CACHE_IDX, cache_path);
        return;
@@ -39,3 +39,7 @@ index 2055c4d863..fdba657953 100644
  #endif
    }
  #endif
+-  File::SetUserPath(D_USER_IDX, user_path);
+ }
+ 
+ void SaveWiimoteSources()

--- a/org.DolphinEmu.dolphin-emu.json
+++ b/org.DolphinEmu.dolphin-emu.json
@@ -76,6 +76,10 @@
           "commit": "28ca6fec9a77b3c4ea58abce558bd79220a2db7d"
         },
         {
+          "type": "patch",
+          "path": "forcexdg.patch"
+        },
+        {
           "type": "file",
           "path": "appdata.xml"
         }


### PR DESCRIPTION
In some cases dolphin would try to use non xdg paths for its configuration files and subsequently be unable to write to them, causing it to crash or otherwise fail.

Fixes #18 