### PR TITLE
Update to 5.0-8987 for the September and October 2018 progress report

### DIFF
--- a/appdata.xml
+++ b/appdata.xml
@@ -23,7 +23,7 @@
     <screenshot>https://raw.githubusercontent.com/flathub/org.DolphinEmu.dolphin-emu/master/screenshots/4.png</screenshot>
   </screenshots>
   <releases>
-    <release date="2018-09-01" version="5.0-8715"/>
+    <release date="2018-11-01" version="5.0-8987"/>
   </releases>
   <update_contact>b@bpiotrowski.pl</update_contact>
 </application>

--- a/org.DolphinEmu.dolphin-emu.json
+++ b/org.DolphinEmu.dolphin-emu.json
@@ -73,7 +73,7 @@
         {
           "type": "git",
           "url": "https://github.com/dolphin-emu/dolphin.git",
-          "commit": "5f0d825f40b8aabe13eaef32d44ab667ff8e8c28"
+          "commit": "22ddd11573fd8d3e43a879804e7a64e50928435d"
         },
         {
           "type": "patch",


### PR DESCRIPTION
I have confirmed through personal testing that the bluetooth passthrough feature does work with this release. However, it requires the user to manually create a udev rule in the host machine as detailed in the dolphin documentation: https://wiki.dolphin-emu.org/index.php?title=USB_Passthrough#Linux

This is hardly ideal, but it's the way upstream recommends, and flatpak doesn't currently offer a means to improve it.