### PR TITLE
fix(build): remove dangling comma

### DIFF
--- a/org.DolphinEmu.dolphin-emu.json
+++ b/org.DolphinEmu.dolphin-emu.json
@@ -15,7 +15,7 @@
     "--socket=x11",
     "--share=network",
     "--share=ipc",
-    "--filesystem=xdg-run/app/com.discordapp.Discord:create",
+    "--filesystem=xdg-run/app/com.discordapp.Discord:create"
   ],
   "modules": [
     {


### PR DESCRIPTION
Fixes build errors seen in #45 

https://flathub.org/builds/#/builders/27/builds/6143

```
flatpak-builder --download-only --no-shallow-clone --allow-missing-runtimes --state-dir=/srv/buildbot/sources /srv/buildbot/sources/.builddir org.DolphinEmu.dolphin-emu.json
 in dir /srv/buildbot/worker/download-sources/build (timeout 3600 secs)
 watching logfiles {}
 argv: [b'flatpak-builder', b'--download-only', b'--no-shallow-clone', b'--allow-missing-runtimes', b'--state-dir=/srv/buildbot/sources', b'/srv/buildbot/sources/.builddir', b'org.DolphinEmu.dolphin-emu.json']
 using PTY: True
Can't parse 'org.DolphinEmu.dolphin-emu.json': <data>:18:61: Parse error: unexpected character `,', expected character `]'
program finished with exit code 1
elapsedTime=0.039274
```