### PR TITLE
Fix version number for netplay

### DIFF
--- a/nodirtyversion.patch
+++ b/nodirtyversion.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9af66009a1..2acd3bed9a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -149,7 +149,7 @@ if(GIT_FOUND)
+       OUTPUT_VARIABLE DOLPHIN_WC_REVISION
+       OUTPUT_STRIP_TRAILING_WHITESPACE)
+   # defines DOLPHIN_WC_DESCRIBE
+-  execute_process(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${GIT_EXECUTABLE} describe --always --long --dirty
++  execute_process(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${GIT_EXECUTABLE} describe --always --long
+       OUTPUT_VARIABLE DOLPHIN_WC_DESCRIBE
+       OUTPUT_STRIP_TRAILING_WHITESPACE)
+ 

--- a/org.DolphinEmu.dolphin-emu.json
+++ b/org.DolphinEmu.dolphin-emu.json
@@ -76,6 +76,10 @@
           "path": "forcexdg.patch"
         },
         {
+          "type": "patch",
+          "path": "nodirtyversion.patch"
+        },
+        {
           "type": "file",
           "path": "appdata.xml"
         },


### PR DESCRIPTION
This changes the build number from the git hash to the one used by other platforms builds.
This allows the NetPlay session browser to match clients of the same version.