### PR TITLE
Bump dependencies

### DIFF
--- a/org.DolphinEmu.dolphin-emu.json
+++ b/org.DolphinEmu.dolphin-emu.json
@@ -31,8 +31,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/libusb/libusb/releases/download/v1.0.22/libusb-1.0.22.tar.bz2",
-          "sha256": "75aeb9d59a4fdb800d329a545c2e6799f732362193b465ea198f2aa275518157"
+          "url": "https://github.com/libusb/libusb/releases/download/v1.0.23/libusb-1.0.23.tar.bz2",
+          "sha256": "db11c06e958a82dac52cf3c65cb4dd2c3f339c8a988665110e0d24d19312ad8d"
         }
       ]
     },

--- a/org.DolphinEmu.dolphin-emu.json
+++ b/org.DolphinEmu.dolphin-emu.json
@@ -2,7 +2,7 @@
   "app-id": "org.DolphinEmu.dolphin-emu",
   "branch": "stable",
   "runtime": "org.kde.Platform",
-  "runtime-version": "5.14",
+  "runtime-version": "5.15",
   "sdk": "org.kde.Sdk",
   "command": "dolphin-emu-wrapper",
   "rename-desktop-file": "dolphin-emu.desktop",


### PR DESCRIPTION
- kde5.15 allows us to upgrade to an fdo20.08 base without needing to manually build qt.
- libusb 1.0.23 was released last year but went unnoticed.