### PR TITLE
Updated to 5.0-14095

### DIFF
--- a/appdata.xml
+++ b/appdata.xml
@@ -21,7 +21,7 @@
     <id>dolphin-emu.desktop</id>
   </provides>
   <releases>
-    <release date="2021-04-05" version="5.0-13963"/>
+    <release date="2021-05-06" version="5.0-14095"/>
   </releases>
   <url type="homepage">https://dolphin-emu.org</url>
   <url type="help">https://forums.dolphin-emu.org</url>

--- a/org.DolphinEmu.dolphin-emu.json
+++ b/org.DolphinEmu.dolphin-emu.json
@@ -80,7 +80,7 @@
         {
           "type": "git",
           "url": "https://github.com/dolphin-emu/dolphin.git",
-          "commit": "5513d5f4f732fb1e436765ab87e7d60ba02b1ad6"
+          "commit": "f60d29f2b79f6e8cca6c00c9b6e8cbfbb0fde6ef"
         },
         {
           "type": "patch",


### PR DESCRIPTION
While there wasn't a new Dolphin progress report, a new Beta version was released, which should warrant an update. The Dolphin developers noted this in their changelog:

> Hey everyone, we don't have a Dolphin Progress Report this month, but it's come to our attention that last month's build had some very annoying regressions. The "Real Wii Remote" option was instantly disconnecting Wii Remotes [...] Considering how many people use our beta builds [...], these regressions were unacceptable to leave unfixed. We're sorry to have to push an impromptu update, but these problems were severe enough that we felt it necessary to do so immediately.

I was personally having some issues with pairing Real Wiimotes, hopefully this will fix that.