### PR TITLE
WIP: Make Real Wii Remote work with emulated Wii bluetooth adapter

### DIFF
--- a/org.DolphinEmu.dolphin-emu.json
+++ b/org.DolphinEmu.dolphin-emu.json
@@ -17,7 +17,8 @@
     "--share=network",
     "--share=ipc",
     "--filesystem=xdg-run/app/com.discordapp.Discord:create",
-    "--talk-name=org.freedesktop.ScreenSaver"
+    "--talk-name=org.freedesktop.ScreenSaver",
+    "--system-talk-name=org.bluez"
   ],
   "modules": [
     {

--- a/org.DolphinEmu.dolphin-emu.json
+++ b/org.DolphinEmu.dolphin-emu.json
@@ -10,6 +10,7 @@
   "rename-appdata-file": "dolphin-emu.appdata.xml",
   "finish-args": [
     "--device=all",
+    "--allow=bluetooth",
     "--filesystem=host:ro",
     "--socket=pulseaudio",
     "--socket=x11",


### PR DESCRIPTION
this is an attempt to fix #66 by getting the "Real Wii Remote" feature under "Emulate the Wii's Bluetooth adapter" to work.

It should not be confused with using real wii remotes with bluetooth passthrough which is a separate feature that already works.