### PR TITLE
Fixed Wayland Support

### DIFF
--- a/org.DolphinEmu.dolphin-emu.yml
+++ b/org.DolphinEmu.dolphin-emu.yml
@@ -13,6 +13,7 @@ finish-args:
   # game directory feature still needs this
   - --filesystem=host:ro
   - --socket=pulseaudio
+  - --env=QT_QPA_PLATFORM=xcb
   - --socket=x11
   - --share=network
   - --share=ipc


### PR DESCRIPTION
We have two problems:

1. Dolphin is not compatible with Wayland (So it would crash)
2. Dolphin is crashing since socket=wayland isn't set

So I added this variable to foce X in XWayland and Dolphin can now start and emulating games.