### PR TITLE
Drop skiparches and arm specific build-options

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-  "skip-arches": ["i386","arm"]
-}

--- a/org.DolphinEmu.dolphin-emu.yml
+++ b/org.DolphinEmu.dolphin-emu.yml
@@ -97,11 +97,6 @@ modules:
       - -DENABLE_SDL=ON
       - -DENABLE_EVDEV=ON
       - -DDISTRIBUTOR=Flathub
-    build-options:
-      arch:
-        arm:
-          config-opts:
-            - -DENABLE_GENERIC=ON
     cleanup:
       - /share/man
     post-install:


### PR DESCRIPTION
flathub won't build for the 32bit arches anyway, this is superfluous.

Also the arm specific build options didn't do anything,
they're just a leftover from when we dropped arm in 2019.