### PR TITLE
Use gtk3 file chooser on steamdeck

### DIFF
--- a/org.DolphinEmu.dolphin-emu.yml
+++ b/org.DolphinEmu.dolphin-emu.yml
@@ -129,5 +129,12 @@ modules:
           - for i in {0..9}; do
           - test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
           - done
-          - dolphin-emu "$@"
+          # use gtk3 filechooser on steamdeck
+          - bv=`cat /sys/devices/virtual/dmi/id/board_vendor`
+          - bv=$bv`cat /sys/devices/virtual/dmi/id/board_name`
+          - if [[ $bv == "ValveJupiter" ]]; then
+          -   QT_QPA_PLATFORMTHEME=gtk3 dolphin-emu "$@"
+          - else
+          -   dolphin-emu "$@"
+          - fi
         dest-filename: dolphin-emu-wrapper


### PR DESCRIPTION
The steamdeck runs kde but has [some issues with the kde portal](https://github.com/flathub/org.DolphinEmu.dolphin-emu/issues/86#issuecomment-1113249128).
As a workaround we're crudely detecting the steamdeck using vendor
strings and setting `QT_QPA_PLATFORMTHEME=gtk3` until a fix comes.