### PR TITLE
Support auto update release version metadata

### DIFF
--- a/org.DolphinEmu.dolphin-emu.appdata.xml
+++ b/org.DolphinEmu.dolphin-emu.appdata.xml
@@ -6,7 +6,7 @@
   <summary>GameCube / Wii / Triforce Emulator</summary>
   <metadata_license>CC-BY-SA-3.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
-  <content_rating type="oars-1.0" />
+  <content_rating type="oars-1.0"/>
   <description><p>Dolphin is an emulator for two recent Nintendo video game consoles: the GameCube and the Wii. It allows PC gamers to enjoy games for these two consoles in full HD (1080p) with several enhancements: compatibility with all PC controllers, turbo speed, networked multiplayer, and even more!</p></description>
   <description xml:lang="pt_BR"><p>O Dolphin é um emulador para dois consoles de vídeo game recentes da Nintendo: o GameCube e o Wii. Ele permite que PC gamers aproveitem jogos destes dois consoles em full HD (1080p) com diversas melhorias: compatibilidade com todos os controles de PC, velocidade turbo, multiplayer em rede e muito mais!</p></description>
   <description xml:lang="es"><p>Dolphin es un emulador para dos consolas recientes de Nintendo: la GameCube y la Wii. Permite que los jugadores de PC disfruten de los juegos de estas dos consolas en alta definición (1080p) con varias mejoras: compatibilidad con todos los mandos de PC, velocidad turbo, multijugador en red, ¡y mucho más!</p></description>
@@ -22,7 +22,7 @@
     <id>dolphin-emu.desktop</id>
   </provides>
   <releases>
-    <release date="2022-07-06" version="5.0-16793"/>
+    <release version="5.0-16793" date="2022-07-06"/>
   </releases>
   <url type="homepage">https://dolphin-emu.org</url>
   <url type="help">https://forums.dolphin-emu.org</url>

--- a/org.DolphinEmu.dolphin-emu.yml
+++ b/org.DolphinEmu.dolphin-emu.yml
@@ -6,7 +6,6 @@ sdk: org.kde.Sdk
 command: dolphin-emu-wrapper
 rename-desktop-file: dolphin-emu.desktop
 rename-icon: dolphin-emu
-rename-appdata-file: dolphin-emu.appdata.xml
 finish-args:
   - --device=all
   # the file picker uses portals but the set
@@ -103,8 +102,8 @@ modules:
     cleanup:
       - /share/man
     post-install:
-      - install -D dolphin-emu-wrapper /app/bin/dolphin-emu-wrapper
-      - install -Dm644 appdata.xml /app/share/appdata/dolphin-emu.appdata.xml
+      - install -D -t ${FLATPAK_DEST}/bin/ dolphin-emu-wrapper
+      - install -Dm644 -t ${FLATPAK_DEST}/share/appdata/ org.DolphinEmu.dolphin-emu.appdata.xml
       - sed -i -e 's/"2048"/"512"/g' /app/share/icons/hicolor/scalable/apps/dolphin-emu.svg
       - desktop-file-edit --set-key=Exec --set-value='/app/bin/dolphin-emu-wrapper'
         /app/share/applications/dolphin-emu.desktop
@@ -116,6 +115,7 @@ modules:
           type: json
           url: https://dolphin-emu.org/update/latest/beta
           commit-query: .hash
+          version-query: .shortrev
       # detects whether dolphin is running in a flatpak sandbox
       # and makes it use xdg directories if it is.
       # prevents dolphin from attempting to write conf files
@@ -127,18 +127,20 @@ modules:
       - type: patch
         path: nodirtyversion.patch
       - type: file
-        path: appdata.xml
+        path: org.DolphinEmu.dolphin-emu.appdata.xml
       - type: script
         commands:
-          - for i in {0..9}; do
-          - test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
-          - done
-          # use gtk3 filechooser on steamdeck
-          - bv=`cat /sys/devices/virtual/dmi/id/board_vendor`
-          - bv=$bv`cat /sys/devices/virtual/dmi/id/board_name`
-          - if [[ $bv == "ValveJupiter" ]]; then
-          -   QT_QPA_PLATFORMTHEME=gtk3 dolphin-emu "$@"
-          - else
-          -   dolphin-emu "$@"
-          - fi
+          - |
+            for i in {0..9}; do
+              test -S $XDG_RUNTIME_DIR/discord-ipc-$i ||
+                ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
+            done
+            # use gtk3 filechooser on steamdeck
+            bv=`cat /sys/devices/virtual/dmi/id/board_vendor`
+            bv=$bv`cat /sys/devices/virtual/dmi/id/board_name`
+            if [[ $bv == "ValveJupiter" ]]; then
+              QT_QPA_PLATFORMTHEME=gtk3 dolphin-emu "$@"
+            else
+              dolphin-emu "$@"
+            fi
         dest-filename: dolphin-emu-wrapper


### PR DESCRIPTION
flatpak-external-data-checker requires appdata.xml to be named org.DolphinEmu.dolphin-emu.appdata.xml to update the releases field.

The formatting changes are to stop f-e-d-c from changing indentation in dolphin-emu-wrapper.