### PR TITLE
Automate release timestamp

### DIFF
--- a/org.DolphinEmu.dolphin-emu.appdata.xml
+++ b/org.DolphinEmu.dolphin-emu.appdata.xml
@@ -22,7 +22,7 @@
     <id>dolphin-emu.desktop</id>
   </provides>
   <releases>
-    <release version="5.0-16793" date="2022-07-06"/>
+    <release version="5.0-16793" date="2022-07-05"/>
   </releases>
   <url type="homepage">https://dolphin-emu.org</url>
   <url type="help">https://forums.dolphin-emu.org</url>

--- a/org.DolphinEmu.dolphin-emu.yml
+++ b/org.DolphinEmu.dolphin-emu.yml
@@ -116,6 +116,8 @@ modules:
           url: https://dolphin-emu.org/update/latest/beta
           commit-query: .hash
           version-query: .shortrev
+          timestamp-query: .date
+          is-main-source: true
       # detects whether dolphin is running in a flatpak sandbox
       # and makes it use xdg directories if it is.
       # prevents dolphin from attempting to write conf files


### PR DESCRIPTION
The dolphin update json now includes a release timestamp: https://github.com/dolphin-emu/www/pull/146