### PR TITLE
Fix German appstream description

### DIFF
--- a/org.DolphinEmu.dolphin-emu.appdata.xml
+++ b/org.DolphinEmu.dolphin-emu.appdata.xml
@@ -7,10 +7,11 @@
   <metadata_license>CC-BY-SA-3.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
   <content_rating type="oars-1.0"/>
+  <!-- Descriptions taken from Dolphin Homepage -->
   <description><p>Dolphin is an emulator for two recent Nintendo video game consoles: the GameCube and the Wii. It allows PC gamers to enjoy games for these two consoles in full HD (1080p) with several enhancements: compatibility with all PC controllers, turbo speed, networked multiplayer, and even more!</p></description>
   <description xml:lang="pt_BR"><p>O Dolphin é um emulador para dois consoles de vídeo game recentes da Nintendo: o GameCube e o Wii. Ele permite que PC gamers aproveitem jogos destes dois consoles em full HD (1080p) com diversas melhorias: compatibilidade com todos os controles de PC, velocidade turbo, multiplayer em rede e muito mais!</p></description>
   <description xml:lang="es"><p>Dolphin es un emulador para dos consolas recientes de Nintendo: la GameCube y la Wii. Permite que los jugadores de PC disfruten de los juegos de estas dos consolas en alta definición (1080p) con varias mejoras: compatibilidad con todos los mandos de PC, velocidad turbo, multijugador en red, ¡y mucho más!</p></description>
-  <description xml:lang="de"><p>Dolphin ist ein Emulator für zwei moderne Videospielkonsolen von Nintendo: Gamecube und Wii. Dolphin erlaubt es PC-Spielern, Spiele für diese beiden Konsolen in FullHD (1080p) mit vielen Verbesserungen zu spielen: Unterstützung für alle PC-Controller, Turbo-Modus, Netzwerk-Mehrspielermodus, und vieles mehr.</p></description>
+  <description xml:lang="de"><p>Dolphin ist ein Emulator für die beiden jungen Nintendo-Konsolen GameCube und Wii. Er ermöglicht PC-Spielern die Spiele dieser beiden Konsolen auf dem PC in Full HD (1080p) mit zahlreichen Verbesserungen zu genießen:Unterstützung für alle PC-Gamecontroller, Turbo-Modus für erhöhte Spielgeschwindigkeit, Mehrspielermodus übers Netzwerk und vieles mehr!</p></description>
   <screenshots>
     <screenshot type="default">https://raw.githubusercontent.com/flathub/org.DolphinEmu.dolphin-emu/master/screenshots/1.png</screenshot>
     <screenshot>https://raw.githubusercontent.com/flathub/org.DolphinEmu.dolphin-emu/master/screenshots/2.png</screenshot>


### PR DESCRIPTION
It seems that the German description translation was re-translated,  instead of using the already translated version from the Dolphin Homepage, which I have fixed in order to keep consistency.

I've also added a comment, so that future translators/contributors don't retranslate, but instead also just pull the content from the Dolphin homepage.