### PR TITLE
Update to 5.0-17995

### DIFF
--- a/org.DolphinEmu.dolphin-emu.appdata.xml
+++ b/org.DolphinEmu.dolphin-emu.appdata.xml
@@ -23,6 +23,7 @@
     <id>dolphin-emu.desktop</id>
   </provides>
   <releases>
+    <release version="5.0-17995" date="2022-12-04"/>
     <release version="5.0-17269" date="2022-09-03"/>
     <release version="5.0-17210" date="2022-08-19"/>
   </releases>

--- a/org.DolphinEmu.dolphin-emu.yml
+++ b/org.DolphinEmu.dolphin-emu.yml
@@ -110,7 +110,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/dolphin-emu/dolphin.git
-        commit: 48c9c224cf9f82f0f9f2690b7cc6283d7448480c
+        commit: 8bad821019721b9b72701b495da95656ace5fea5
         x-checker-data:
           type: json
           url: https://dolphin-emu.org/update/latest/beta


### PR DESCRIPTION
Essentially https://github.com/flathub/org.DolphinEmu.dolphin-emu/pull/136 but without broken bluez update.

I tested performance of Super Mario Galaxy on Steam Deck, and this version improves it a lot.

The patches are still necessary, and Steam Deck hack is still necessary for SteamOS Stable (however it's not necessary for Beta).