### PR TITLE
Remove Steam Deck filepicker hack

### DIFF
--- a/org.DolphinEmu.dolphin-emu.yml
+++ b/org.DolphinEmu.dolphin-emu.yml
@@ -137,12 +137,5 @@ modules:
               test -S $XDG_RUNTIME_DIR/discord-ipc-$i ||
                 ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
             done
-            # use gtk3 filechooser on steamdeck
-            bv=`cat /sys/devices/virtual/dmi/id/board_vendor`
-            bv=$bv`cat /sys/devices/virtual/dmi/id/board_name`
-            if [[ $bv == "ValveJupiter" ]]; then
-              QT_QPA_PLATFORMTHEME=gtk3 dolphin-emu "$@"
-            else
-              dolphin-emu "$@"
-            fi
+            dolphin-emu "$@"
         dest-filename: dolphin-emu-wrapper


### PR DESCRIPTION
With the release of SteamOS 3.4 it's no longer necessary: https://steamcommunity.com/games/1675200/announcements/detail/3646258449514531839.