### PR TITLE
Remove host filesystem permission

### DIFF
--- a/org.DolphinEmu.dolphin-emu.yml
+++ b/org.DolphinEmu.dolphin-emu.yml
@@ -8,9 +8,6 @@ rename-desktop-file: dolphin-emu.desktop
 rename-icon: dolphin-emu
 finish-args:
   - --device=all
-  # the file picker uses portals but the set
-  # game directory feature still needs this
-  - --filesystem=host:ro
   - --socket=pulseaudio
   - --env=QT_QPA_PLATFORM=xcb
   - --socket=x11


### PR DESCRIPTION
I'm not sure host filesystem access is still needed, perhaps after https://github.com/qt/qtbase/commit/844967d297327dc72a1aa67644c1b2fa3fe6839c
This will mean users have to set their game folders list again.