### PR TITLE
Upgrade runtime to 6.5

### DIFF
--- a/org.DolphinEmu.dolphin-emu.yml
+++ b/org.DolphinEmu.dolphin-emu.yml
@@ -1,7 +1,7 @@
 app-id: org.DolphinEmu.dolphin-emu
 branch: stable
 runtime: org.kde.Platform
-runtime-version: 6.4
+runtime-version: '6.5'
 sdk: org.kde.Sdk
 command: dolphin-emu-wrapper
 rename-desktop-file: dolphin-emu.desktop


### PR DESCRIPTION
`runtime-version` has also been changed to a string, which is usually supposed to be.