### PR TITLE
removed host filesystem access, replaced with sane locations

### DIFF
--- a/org.DolphinEmu.dolphin-emu.yml
+++ b/org.DolphinEmu.dolphin-emu.yml
@@ -10,7 +10,12 @@ finish-args:
   - --device=all
   # the file picker uses portals but the set
   # game directory feature still needs this
-  - --filesystem=host:ro
+  - --filesystem=home:ro
+  - --filesystem=/media:ro
+  - --filesystem=/mnt:ro
+  - --filesystem=/run/media:ro
+  - --filesystem=/var/run/media:ro
+  - --filesystem=/var/mnt:ro
   - --socket=pulseaudio
   - --env=QT_QPA_PLATFORM=xcb
   - --socket=x11


### PR DESCRIPTION
it should not have host access. Unclear what should be accomplished by using :ro does it work without saving files?

This is not hardening, its simply all the locations media file actually are at. Its a start for easier hardening also for users

  - --filesystem=home
  - --filesystem=/media
  - --filesystem=/mnt
  - --filesystem=/run/media
  - --filesystem=/var/run/media
  - --filesystem=/var/mnt