### PR TITLE
Use platform bluez

### DIFF
--- a/org.DolphinEmu.dolphin-emu.yml
+++ b/org.DolphinEmu.dolphin-emu.yml
@@ -16,8 +16,7 @@ finish-args:
   - --socket=x11
   - --share=network
   - --share=ipc
-  # along with the bluez module, required for the
-  # emulated bluetooth adapter feature to work.
+  # required for the emulated bluetooth adapter feature to work.
   - --allow=bluetooth
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --talk-name=org.freedesktop.ScreenSaver
@@ -39,35 +38,6 @@ modules:
           project-id: 1749
           stable-only: true
           url-template: https://github.com/libusb/libusb/releases/download/v$version/libusb-$version.tar.bz2
-
-  # needed for the emulate bluetooth adapter feature to work
-  - name: bluez
-    config-opts:
-      - --enable-library
-      - --disable-manpages
-      - --disable-udev
-      - --disable-tools
-      - --disable-cups
-      - --disable-monitor
-      - --disable-client
-      - --disable-systemd
-      - --disable-a2dp
-      - --disable-avrcp
-      - --disable-network
-      - --disable-obex
-      - --disable-bap
-      - --disable-mcp
-      - --with-dbusconfdir=/app/etc
-      - --with-dbussessionbusdir=/app/usr/lib/system-services
-    sources:
-      - type: archive
-        url: https://www.kernel.org/pub/linux/bluetooth/bluez-5.69.tar.xz
-        sha256: bc5a35ddc7c72d0d3999a0d7b2175c8b7d57ab670774f8b5b4900ff38a2627fc
-        x-checker-data:
-          type: anitya
-          project-id: 10029
-          stable-only: true
-          url-template: https://www.kernel.org/pub/linux/bluetooth/bluez-$version.tar.xz
 
   # enables motion controls on non-wii controllers (switch, ps4, etc)
   # requires a udev rule enabling Motion Sensors access


### PR DESCRIPTION
freedesktop 22.08 adds bluez (`libbluetooth.so`)

I was trying to figure out some flatpak bluetooth stuff when I found my old comment https://github.com/flathub/org.DolphinEmu.dolphin-emu/pull/70#issuecomment-856052201
> I would have thought bluez libs would be available in one of the freedesktop runtimes, not sure how to conveniently check for this.

I have since figured out how to conveniently check this:
```bash
diff <(flatpak run --system --command=find org.freedesktop.Platform//21.08 /usr -name '*bluetooth*') \
     <(flatpak run --system --command=find org.freedesktop.Platform//22.08 /usr -name '*bluetooth*')
```
```diff
0a1,2
> /usr/lib/x86_64-linux-gnu/libbluetooth.so.3
> /usr/lib/x86_64-linux-gnu/libbluetooth.so.3.19.8
```