### PR TITLE
Remove branch field

### DIFF
--- a/org.DolphinEmu.dolphin-emu.yml
+++ b/org.DolphinEmu.dolphin-emu.yml
@@ -1,5 +1,4 @@
 app-id: org.DolphinEmu.dolphin-emu
-branch: stable
 runtime: org.kde.Platform
 runtime-version: '6.5'
 sdk: org.kde.Sdk


### PR DESCRIPTION
Is there any reason for this line?
When I build most flatpak packages locally I can run them with `flatpak run org.DolphinEmu.dolphin-emu//master`.
With this repo I have to make sure the `flatpak-builder` command includes a `--user` so it doesn't complain that `org.DolphinEmu.dolphin-emu//stable` is already installed.