### PR TITLE
Grant access to Gamescope socket on Steam Deck

### DIFF
--- a/org.DolphinEmu.dolphin-emu.yml
+++ b/org.DolphinEmu.dolphin-emu.yml
@@ -20,8 +20,8 @@ finish-args:
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --talk-name=org.freedesktop.ScreenSaver
   # required for Gamescope on Steam Deck
-  - --env=PATH=$PATH:/usr/lib/extensions/vulkan/gamescope/bin
-  - --env=LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/extensions/vulkan/gamescope/lib
+  - --env=PATH=/app/bin:/app/utils/bin:/usr/bin:/usr/lib/extensions/vulkan/gamescope/bin
+  - --env=LD_LIBRARY_PATH=/usr/lib/extensions/vulkan/gamescope/lib
   - --filesystem=xdg-run/gamescope-0:ro
 modules:
   # needed for the bluetooth passthrough feature to work

--- a/org.DolphinEmu.dolphin-emu.yml
+++ b/org.DolphinEmu.dolphin-emu.yml
@@ -20,7 +20,8 @@ finish-args:
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --talk-name=org.freedesktop.ScreenSaver
   # required for Gamescope on Steam Deck
-  - --env=LD_LIBRARY_PATH=/usr/lib/extensions/vulkan/gamescope/lib
+  - --env=PATH=$PATH:/usr/lib/extensions/vulkan/gamescope/bin
+  - --env=LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/extensions/vulkan/gamescope/lib
   - --filesystem=xdg-run/gamescope-0:ro
 modules:
   # needed for the bluetooth passthrough feature to work

--- a/org.DolphinEmu.dolphin-emu.yml
+++ b/org.DolphinEmu.dolphin-emu.yml
@@ -20,8 +20,6 @@ finish-args:
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --talk-name=org.freedesktop.ScreenSaver
   # required for Gamescope on Steam Deck
-  - --env=PATH=/app/bin:/app/utils/bin:/usr/bin:/usr/lib/extensions/vulkan/gamescope/bin
-  - --env=LD_LIBRARY_PATH=/usr/lib/extensions/vulkan/gamescope/lib
   - --filesystem=xdg-run/gamescope-0:ro
 modules:
   # needed for the bluetooth passthrough feature to work

--- a/org.DolphinEmu.dolphin-emu.yml
+++ b/org.DolphinEmu.dolphin-emu.yml
@@ -19,6 +19,9 @@ finish-args:
   - --allow=bluetooth
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --talk-name=org.freedesktop.ScreenSaver
+  # required for Gamescope on Steam Deck
+  - --env=LD_LIBRARY_PATH=/usr/lib/extensions/vulkan/gamescope/lib
+  - --filesystem=xdg-run/gamescope-0:ro
 modules:
   # needed for the bluetooth passthrough feature to work
   - name: libusb


### PR DESCRIPTION
I encounter this error every time I launch a Dolphin game through Steam Deck's Game Mode UI:
![20240120_180303](https://github.com/flathub/org.DolphinEmu.dolphin-emu/assets/99134546/5a4b3ca1-99ae-41e2-9af8-6d2591799d27)

I've encountered it many times before when launching games through other Flatpaks, like those for Lutris, Heroic, and other emulators. Recently, I found that this error went away after adding support for HDR on Steam Deck to [Lutris Flatpak](https://github.com/flathub/net.lutris.Lutris/commit/3ec57b415882054d06668911aaa73761dfd47d14) -- itself based on the method used for enabling HDR support on [Heroic](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3281#issuecomment-1886180726) and [Chiaki4deck](https://github.com/streetpea/chiaki4deck/issues/93#issuecomment-1830897848). So I'm pushing this PR that I believe will give Dolphin Flatpak access to the Gamescope socket. I'm leaving this PR as draft for now until I've run the test build to confirm it works.

Similar to PRs I have made for [RetroArch](https://github.com/flathub/org.libretro.RetroArch/pull/278), [PrimeHack](https://github.com/flathub/io.github.shiiion.primehack/pull/28), and [PPSSPP](https://github.com/flathub/org.ppsspp.PPSSPP/pull/73), I have tested and confirmed that just adding the gamescope-0 socket is enough to make the error go away, with no apparent regressions, if you have the Gamescope Flatpak installed:
```bash
flatpak install flathub org.freedesktop.Platform.VulkanLayer.gamescope
```