### PR TITLE
Update libevdev and dolphin-emu modules

### DIFF
--- a/org.DolphinEmu.dolphin-emu.appdata.xml
+++ b/org.DolphinEmu.dolphin-emu.appdata.xml
@@ -22,6 +22,9 @@
     <id>dolphin-emu.desktop</id>
   </provides>
   <releases>
+    <release version="2407" date="2024-07-02">
+      <description></description>
+    </release>
     <release version="5.0-21460" date="2024-04-29"/>
     <release version="5.0-21264" date="2024-03-26"/>
     <release version="5.0-21088" date="2024-02-05"/>

--- a/org.DolphinEmu.dolphin-emu.yml
+++ b/org.DolphinEmu.dolphin-emu.yml
@@ -49,8 +49,8 @@ modules:
       - -Ddocumentation=disabled
     sources:
       - type: archive
-        url: https://www.freedesktop.org/software/libevdev/libevdev-1.13.1.tar.xz
-        sha256: 06a77bf2ac5c993305882bc1641017f5bec1592d6d1b64787bad492ab34f2f36
+        url: https://www.freedesktop.org/software/libevdev/libevdev-1.13.2.tar.xz
+        sha256: 3eca86a6ce55b81d5bce910637fc451c8bbe373b1f9698f375c7f1ad0de3ac48
         x-checker-data:
           type: anitya
           project-id: 20540
@@ -78,13 +78,14 @@ modules:
     post-install:
       - install -D -t ${FLATPAK_DEST}/bin/ dolphin-emu-wrapper
       - install -Dm644 -t ${FLATPAK_DEST}/share/appdata/ org.DolphinEmu.dolphin-emu.appdata.xml
-      - sed -i -e 's/"2048"/"512"/g' /app/share/icons/hicolor/scalable/apps/dolphin-emu.svg
+      - sed -i -e 's/viewBox="0 0 1024.02 571.29"/viewBox="0 -285.645 1024 1024" width="2048"
+        height="2048"/g' /app/share/icons/hicolor/scalable/apps/dolphin-emu.svg
       - desktop-file-edit --set-key=Exec --set-value='/app/bin/dolphin-emu-wrapper'
         /app/share/applications/dolphin-emu.desktop
     sources:
       - type: git
         url: https://github.com/dolphin-emu/dolphin.git
-        commit: a9544510468740b77cf06ef28daaa65fe247fd32
+        commit: b92e354389bb7c0bd114a8631b8af110d3cb3a14
         x-checker-data:
           type: json
           url: https://dolphin-emu.org/update/latest/beta


### PR DESCRIPTION
libevdev: Update libevdev-1.13.1.tar.xz to 1.13.2
dolphin-emu: Update dolphin.git to 2407

This also fiddles with the `viewBox` of the icon svg to make it square.