### PR TITLE
Revert "Bump to dev for RetroAchievements support"

### DIFF
--- a/org.DolphinEmu.dolphin-emu.appdata.xml
+++ b/org.DolphinEmu.dolphin-emu.appdata.xml
@@ -22,8 +22,6 @@
     <id>dolphin-emu.desktop</id>
   </provides>
   <releases>
-    <release version="2407-68" date="2024-07-16"/>
-    <release version="2407-64" date="2024-07-15"/>
     <release version="2407" date="2024-07-02"/>
     <release version="5.0-21460" date="2024-04-29"/>
     <release version="5.0-21264" date="2024-03-26"/>

--- a/org.DolphinEmu.dolphin-emu.yml
+++ b/org.DolphinEmu.dolphin-emu.yml
@@ -85,14 +85,14 @@ modules:
     sources:
       - type: git
         url: https://github.com/dolphin-emu/dolphin.git
-        commit: cc3ff347b437fd80f3a2880d1bbc7ba2d5f191f4
-        # x-checker-data:
-        #   type: json
-        #   url: https://dolphin-emu.org/update/latest/beta
-        #   commit-query: .hash
-        #   version-query: .shortrev
-        #   timestamp-query: .date
-        #   is-main-source: true
+        commit: b92e354389bb7c0bd114a8631b8af110d3cb3a14
+        x-checker-data:
+          type: json
+          url: https://dolphin-emu.org/update/latest/beta
+          commit-query: .hash
+          version-query: .shortrev
+          timestamp-query: .date
+          is-main-source: true
       # detects whether dolphin is running in a flatpak sandbox
       # and makes it use xdg directories if it is.
       # prevents dolphin from attempting to write conf files


### PR DESCRIPTION
This reverts commit 9ecb23d1cd3a21b5e8edbf34316a18c4f54862b1.

Fixes #203, #204.

Retroachievements support is available on flathub-beta.