### PR TITLE
Mark beta branch as eol

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+  "end-of-life": "There will be no more beta builds, please switch back to stable to continue getting updates. More information here: https://github.com/flathub/org.DolphinEmu.dolphin-emu?tab=readme-ov-file#beta-branch"
+}
+


### PR DESCRIPTION
The beta branch is redundant now that there are official dev builds from the dolphin ci.