### PR TITLE
screensaver inhibition: drop shim and add permissions for older systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,13 @@ At the moment the only realistic usage case for this are HDR10 filters if you ha
 
 ### talk-name=org.freedesktop.ScreenSaver
 
-Required for screensaver inhibition during gameplay.
+Also `--talk-name=org.xfce.ScreenSaver` and `--talk-name=org.mate.ScreenSaver`.
 
-It can be disabled but your screensaver might trigger during gameplay depending on your input device and screensaver configuration.
+These are required for screensaver inhibition during gameplay on systems with old or defective portal implementations.
+
+If you're on a desktop with a newer portal implementation it's safe to disable all of these.
+
+You can also disable them on older systems, but your screensaver might trigger during gameplay depending on your input device and screensaver configuration.
 
 ## dolphin-tool
 

--- a/org.DolphinEmu.dolphin-emu.yml
+++ b/org.DolphinEmu.dolphin-emu.yml
@@ -18,7 +18,11 @@ finish-args:
   # required for the emulated bluetooth adapter feature to work.
   - --allow=bluetooth
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
+  # required for screensaver inhibition on desktops with
+  # old or defective portal implementations.
   - --talk-name=org.freedesktop.ScreenSaver
+  - --talk-name=org.xfce.ScreenSaver
+  - --talk-name=org.mate.ScreenSaver
   # required for Gamescope on Steam Deck
   - --filesystem=xdg-run/gamescope-0:ro
 modules:
@@ -56,14 +60,6 @@ modules:
           project-id: 20540
           stable-only: true
           url-template: https://www.freedesktop.org/software/libevdev/libevdev-$version.tar.xz
-
-  # needed for screensaver inhibition
-  - name: xdg-screensaver-shim
-    buildsystem: meson
-    sources:
-      - type: archive
-        url: https://github.com/Unrud/xdg-screensaver-shim/archive/0.0.2.tar.gz
-        sha256: 0ed2a69fe6ee6cbffd2fe16f85116db737f17fb1e79bfb812d893cf15c728399
 
   - name: dolphin-emu
     buildsystem: cmake-ninja


### PR DESCRIPTION
The shim is no longer needed, dolphin handles all the cases directly over dbus.

On current versions of kde and gnome this works through the portal without any issues, but permissions have been added in order to handle older versions and desktops were the portal isn't available or doesn't work properly.