### PR TITLE
WIP Update runtime to 6.10

### DIFF
--- a/org.DolphinEmu.dolphin-emu.yml
+++ b/org.DolphinEmu.dolphin-emu.yml
@@ -51,7 +51,6 @@ modules:
       - -DENABLE_SDL=ON
       - -DENABLE_EVDEV=ON
       - -DDISTRIBUTOR=Flathub
-      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     cleanup:
       - /share/man
     post-install:


### PR DESCRIPTION
`libusb` is in the runtime now and can be removed, see #358 

~~Builds fine but fails to start because of a freedesktop SDK bug [(see here)](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1914). Has to wait for the next release of the freedesktop SDK.~~ should be fixed now